### PR TITLE
Support asynchronous predicate and updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,31 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support async predicate
+   - `await updateIn([1, 2, 3, 4, 5], [v => Promise.resolve(v % 2)], v => v * 10)` will return `[10, 2, 30, 4, 50]`
+- Support async update
+   - `await updateIn([1, 2, 3], [0], v => Promise.resolve(v * 10))` will return `[10, 2, 3]`
+
 ### Changed
 - Bump to `@babel/core@7.1.2` and `jest@23.6.0`
 - Add default exports for CommonJS
 
+### Removed
+- Removed array insertion using index number of `-1`
+   - This introduces API inconfirmity: `-1` could means append, prepend, or the last item
+
 ## [1.3.1] - 2018-10-05
 ### Fixed
 - Using a predicate on a non-existing key/index should not throw error and return the original value as-is
-  - `updateIn({}, ['Hello', () => true], () => 'World!'])` will return `{}`
-  - `updateIn([], [0, () => true], () => 'Aloha'])` will return `[]`
+   - `updateIn({}, ['Hello', () => true], () => 'World!'])` will return `{}`
+   - `updateIn([], [0, () => true], () => 'Aloha'])` will return `[]`
 
 ## [1.3.0] - 2018-08-17
 ### Added
 - Support predicate function
-  - `updateIn([1, 2, 3, 4, 5], [v => v % 2], v => v * 10)` will return `[10, 2, 30, 4, 50]`
-  - Predicate function can be used as branching function to update multiple subtrees in a single call
+   - `updateIn([1, 2, 3, 4, 5], [v => v % 2], v => v * 10)` will return `[10, 2, 30, 4, 50]`
+   - Predicate function can be used as branching function to update multiple subtrees in a single call
 
 ## [1.2.0] - 2018-04-14
 ### Added
@@ -28,7 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Append not creating sub-structure correctly
-  - `updateIn([1, 2], [-1, 0], 'Hello')` should return `[1, 2, ['Hello']]` instead of `[1, 2, 'Hello']`
+   - `updateIn([1, 2], [-1, 0], 'Hello')` should return `[1, 2, ['Hello']]` instead of `[1, 2, 'Hello']`
 
 ## [1.1.1] - 2018-04-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For active development (`master` branch), run `npm install simple-update-in@mast
 
 # How to use
 
-For example, `obj.one.two = 1.2`, call `updateIn(obj, ['one', 'two'], 1.2)`. It will return a new object with changes in deep clone.
+For example, `obj.one.two = 1.2`, call `updateIn(obj, ['one', 'two'], () => 1.2)`. It will return a new object with changes in deep clone.
 
 We share similar signature as [ImmutableJS.updateIn](https://facebook.github.io/immutable-js/docs/#/Map/updateIn):
 
@@ -135,7 +135,20 @@ const actual = updateIn(from, ['one']);
 expect(actual).toEqual({});
 ```
 
-## Adding an item to array
+## ~~Adding an item to array~~
+
+This feature has been removed due to inconformity of the API. `-1` could means append, prepend, or it could means last value (item at `length - 1`).
+
+For append, you can use the following code
+
+```js
+const from = [0, 1];
+const actual = updateIn(from, [], array => [...array, 2]);
+
+expect(actual).toEqual([0, 1, 2]);
+```
+
+### Removed documentation
 
 You can use special index value `-1` to indicate an append to the array.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ expect(actual).toEqual(['zero', 'two']);
 
 > Also for `updater` returning `undefined`
 
+### Asynchronous update
+
+You can also use an asynchronous updater to update the content. Instead of using the exported `default` function, you will need to use the `updateInAsync` function instead.
+
+```js
+import { updateInAsync } from 'simple-update-in';
+
+const from = { one: [1.1, 1.2, 1.3], two: [2] };
+const actual = await updateInAsync(from, ['one', 1], value => Promise.resolve('one point two'));
+
+expect(actual).toEqual({ one: [1.1, 'one point two', 1.3], two: [2] });
+```
+
 ## Automatic expansion
 
 ```js
@@ -210,6 +223,19 @@ const from = [];
 const actual = updateIn(from, [0, () => true], () => 'Aloha']);
 
 expect(actual).toBe(from);
+```
+
+### Asynchronous predicate
+
+You can also use asynchronous predicate. Instead of using the exported `default` function, you will need to use the `updateInAsync` function instead.
+
+```js
+import { updateInAsync } from 'simple-update-in';
+
+const from = [1, 2, 3, 4, 5];
+const actual = await updateInAsync(from, [value => Promise.resolve(value % 2)], value => value * 10);
+
+expect(actual).toEqual([10, 2, 30, 4, 50]);
 ```
 
 # Contributions

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/compulim/simple-update-in#readme",
   "jest": {
-    "collectCoverage": true
+    "collectCoverage": true,
+    "testEnvironment": "node"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,26 @@
-export default function simpleUpdateIn(obj, path, updater) {
+export default function (obj, path, updater) {
   const paths = getPaths(obj, path);
 
   for (let path of paths) {
-    const value = getValue(obj, path);
-    let nextValue;
+    obj = setValue(
+      obj,
+      path,
+      updater ? updater(getValue(obj, path)) : undefined
+    );
+  }
 
-    nextValue = updater ? updater(value) : undefined;
-    obj = setValue(obj, path, nextValue);
+  return obj;
+}
+
+export async function asyncUpdateIn(obj, path, updater) {
+  const paths = getPaths(obj, path);
+
+  for (let path of paths) {
+    obj = setValue(
+      obj,
+      path,
+      updater ? await updater(getValue(obj, path)) : undefined
+    );
   }
 
   return obj;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,4 +1,4 @@
-import updateIn, { getPaths } from './index';
+import updateIn, { asyncUpdateIn } from './index';
 
 test('set in flat map', () => {
   const from = { abc: 123, def: 456 };
@@ -337,4 +337,24 @@ test('map with non-existing key followed by a predicate', () => {
   // Since "abc" does not exist in the map, based on the predicate, we cannot predict whether it will be an array or map.
   // Either way, the predicate will not able to match anything, thus, it will be no-op.
   expect(actual).toBe(from);
+});
+
+test('update map using Promise', async () => {
+  const from = { abc: 123, def: 456 };
+  const actual = await asyncUpdateIn(from, ['xyz'], () => Promise.resolve(789));
+
+  expect(from).not.toBe(actual);
+  expect(actual).toEqual({
+    abc: 123,
+    def: 456,
+    xyz: 789
+  });
+});
+
+test('remove in map using async version', async () => {
+  const from = { abc: 123, def: 456 };
+  const actual = await asyncUpdateIn(from, ['def']);
+
+  expect(from).not.toBe(actual);
+  expect(actual).toEqual({ abc: 123 });
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,4 +1,4 @@
-import updateIn from './index';
+import updateIn, { getPaths } from './index';
 
 test('set in flat map', () => {
   const from = { abc: 123, def: 456 };
@@ -162,21 +162,21 @@ test('incompatible type convert string to map', () => {
   expect(actual).toEqual({ one: 1 });
 });
 
-test('append to array', () => {
-  const from = [0, 1, 2];
-  const actual = updateIn(from, [-1], () => 3);
+// test('append to array', () => {
+//   const from = [0, 1, 2];
+//   const actual = updateIn(from, [-1], () => 3);
 
-  expect(from).not.toBe(actual);
-  expect(actual).toEqual([0, 1, 2, 3]);
-});
+//   expect(from).not.toBe(actual);
+//   expect(actual).toEqual([0, 1, 2, 3]);
+// });
 
-test('append to array 2', () => {
-  const from = [0, 1, 2];
-  const actual = updateIn(from, [-1, 0, 0], () => 3);
+// test('append to array 2', () => {
+//   const from = [0, 1, 2];
+//   const actual = updateIn(from, [-1, 0, 0], () => 3);
 
-  expect(from).not.toBe(actual);
-  expect(actual).toEqual([0, 1, 2, [[3]]]);
-});
+//   expect(from).not.toBe(actual);
+//   expect(actual).toEqual([0, 1, 2, [[3]]]);
+// });
 
 test('modifying undefined in map', () => {
   const from = { one: 1 };


### PR DESCRIPTION
Fix #7 and #9.

### Added
- Support async predicate
   - `await updateIn([1, 2, 3, 4, 5], [v => Promise.resolve(v % 2)], v => v * 10)` will return `[10, 2, 30, 4, 50]`
- Support async update
   - `await updateIn([1, 2, 3], [0], v => Promise.resolve(v * 10))` will return `[10, 2, 3]`

### Removed
- Removed array insertion using index number of `-1`
   - This introduces API inconfirmity: `-1` could means append, prepend, or the last item
