### PR TITLE
Add dist to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "browser": "dist/simple-update-in.production.min.js",
   "main": "lib/index.js",
   "files": [
+    "dist/**/*",
     "lib/**/*"
   ],
   "scripts": {


### PR DESCRIPTION
We are missing `/dist/` in `files` so we are not publishing `/dist/simple-update-in.development.js` to NPM.