### PR TITLE
Fix parents should not be removed when updater is or returned undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix [#16](https://github.com/compulim/simple-update-in/issues/16), parents should not be removed when `updater` is or returned `undefined`, in PR [#17](https://github.com/compulim/simple-update-in/issues/17)
 
 ## [2.0.1] - 2018-12-03
 ### Added

--- a/src/index.js
+++ b/src/index.js
@@ -99,12 +99,11 @@ function getValue(obj, path) {
 }
 
 function setValue(obj, path, target) {
-  const [accessor, ...nextPath] = path;
-
   if (!path.length) {
     return target;
   }
 
+  const [accessor, ...nextPath] = path;
   const value = typeof obj !== 'undefined' && obj[accessor];
   let nextObj = obj;
 
@@ -115,9 +114,21 @@ function setValue(obj, path, target) {
   }
 
   if (typeof accessor === 'number') {
-    if (typeof target !== 'undefined') {
-      const nextValue = setValue(value, nextPath, target);
+    const nextValue = setValue(value, nextPath, target);
 
+    if (typeof nextValue === 'undefined') {
+      if (typeof obj === 'undefined') {
+        return obj;
+      } else {
+        // If updater returned undefined or no updater at all, delete the item
+        if (accessor in nextObj) {
+          nextObj = [...nextObj];
+          nextObj.splice(accessor, 1);
+        }
+
+        return nextObj;
+      }
+    } else {
       if (nextValue === value) {
         return obj;
       } else {
@@ -127,18 +138,22 @@ function setValue(obj, path, target) {
         return nextObj;
       }
     }
-
-    // If updater returned undefined or no updater at all, delete the item
-    if (accessor in nextObj) {
-      nextObj = [...nextObj];
-      nextObj.splice(accessor, 1);
-    }
-
-    return nextObj;
   } else {
-    if (typeof target !== 'undefined') {
-      const nextValue = setValue(value, nextPath, target);
+    const nextValue = setValue(value, nextPath, target);
 
+    if (typeof nextValue === 'undefined') {
+      if (typeof obj === 'undefined') {
+        return obj;
+      } else {
+        // If updater returned undefined or no updater at all, delete the key
+        if (accessor in nextObj) {
+          nextObj = { ...nextObj };
+          delete nextObj[accessor];
+        }
+
+        return nextObj;
+      }
+    } else {
       if (nextValue === value) {
         return obj;
       } else {
@@ -148,13 +163,5 @@ function setValue(obj, path, target) {
         };
       }
     }
-
-    // If updater returned undefined or no updater at all, delete the key
-    if (accessor in nextObj) {
-      nextObj = { ...nextObj };
-      delete nextObj[accessor];
-    }
-
-    return nextObj;
   }
 }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -45,6 +45,16 @@ test('remove in map', () => {
   expect(actual).not.toHaveProperty('three');
 });
 
+test('remove in map 2', () => {
+  const from = { odd: { one: 1, three: 3 }, even: { two: 2 } };
+  const actual = updateIn(from, ['odd', 'three']);
+
+  expect(from).not.toBe(actual);
+  expect(from.even).toBe(actual.even);
+  expect(actual).toEqual({ odd: { one: 1 }, even: { two: 2 } });
+  expect(actual).not.toHaveProperty('odd.three');
+});
+
 test('set in flat array', () => {
   const from = [0, 1, 2];
   const actual = updateIn(from, [1], () => 3);
@@ -77,6 +87,15 @@ test('remove in array', () => {
 
   expect(from).not.toBe(actual);
   expect(actual).toEqual([0, 2]);
+});
+
+test('remove in array 2', () => {
+  const from = [[1, 3], [2, 4]];
+  const actual = updateIn(from, [0, 1]);
+
+  expect(actual).not.toBe(from);
+  expect(actual[1]).toBe(from[1]);
+  expect(actual).toEqual([[1], [2, 4]]);
 });
 
 test('mix map/array', () => {
@@ -182,12 +201,12 @@ test('modifying undefined in map', () => {
   const from = { one: 1 };
   const actual = updateIn(from, ['two', 'three'], value => value && value * 10);
 
-  expect(from).toBe(actual);
+  expect(actual).toBe(from);
 });
 
 test('modifying undefined in array', () => {
   const from = [0, 1, 2, 3];
-  const actual = updateIn(from, [4], value => value && value * 10);
+  const actual = updateIn(from, [4, 5], value => value && value * 10);
 
   expect(from).toBe(actual);
 });


### PR DESCRIPTION
Fix #16.

### Fixed
- Fix [#16](https://github.com/compulim/simple-update-in/issues/16), parents should not be removed when `updater` is or returned `undefined`, in PR [#17](https://github.com/compulim/simple-update-in/issues/17)