### PR TITLE
Prevent modifying reserved keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
 - "10"
 - "11"
+- "12"
 
 before_script:
 - npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - [`rollup-plugin-uglify@^6.0.2`](https://www.npmjs.com/package/rollup-plugin-uglify)
 
 ### Added
-- Will not modify `__proto__`, `constructor`, and `prototype`, in PR [#19](https://github.com/compulim/simple-update-in/pull/19)
+- Will not modify paths containing `__proto__`, `constructor`, and `prototype`, in PR [#19](https://github.com/compulim/simple-update-in/pull/19)
 
 ## [2.0.2] - 2018-12-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - [`rollup-plugin-babel@^4.3.3`](https://www.npmjs.com/package/rollup-plugin-babel)
    - [`rollup-plugin-uglify@^6.0.2`](https://www.npmjs.com/package/rollup-plugin-uglify)
 
+### Added
+- Will not modify `__proto__`, `constructor`, and `prototype`, in PR [#19](https://github.com/compulim/simple-update-in/pull/19)
+
 ## [2.0.2] - 2018-12-06
 ### Fixed
-- Fix [#16](https://github.com/compulim/simple-update-in/issues/16), parents should not be removed when `updater` is or returned `undefined`, in PR [#17](https://github.com/compulim/simple-update-in/issues/17)
+- Fix [#16](https://github.com/compulim/simple-update-in/issues/16), parents should not be removed when `updater` is or returned `undefined`, in PR [#17](https://github.com/compulim/simple-update-in/pull/17)
 
 ## [2.0.1] - 2018-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - [`rollup-plugin-uglify@^6.0.2`](https://www.npmjs.com/package/rollup-plugin-uglify)
 
 ### Added
-- Will not modify paths containing `__proto__`, `constructor`, and `prototype`, in PR [#19](https://github.com/compulim/simple-update-in/pull/19)
+- Will skip paths containing `__proto__`, `constructor`, and `prototype`, in PR [#19](https://github.com/compulim/simple-update-in/pull/19)
 
 ## [2.0.2] - 2018-12-06
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ expect(actual.thirty).toBe(30);  // We multiplied it by 10
 
 > This is in fact an "upsert" operation.
 
+> Note: for security reason, we will not modify path containing `__proto__`, `constructor`, `prototype`.
+
 ### Array in map
 
 ```js

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ expect(actual.thirty).toBe(30);  // We multiplied it by 10
 
 > This is in fact an "upsert" operation.
 
-> Note: for security reason, we will not modify path containing `__proto__`, `constructor`, `prototype`.
+> Note: for security reason, we will skip paths containing `__proto__`, `constructor`, `prototype`. This includes [predicate paths](#using-predicate).
 
 ### Array in map
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,12 @@ function validatePath(path) {
   }
 }
 
+const RESERVED_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+function reserved(key) {
+  return RESERVED_KEYS.includes(key);
+}
+
 function getPaths(obj, path) {
   if (!path.length) {
     return;
@@ -106,6 +112,10 @@ function setValue(obj, path, target) {
   const [accessor, ...nextPath] = path;
   const value = typeof obj !== 'undefined' && obj[accessor];
   let nextObj = obj;
+
+  if (reserved(accessor)) {
+    return obj;
+  }
 
   if (typeof accessor === 'string' && (typeof nextObj !== 'object' || Array.isArray(nextObj))) {
     nextObj = {};

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -417,23 +417,37 @@ test('map with reserved key "prototype"', () => {
   expect(from).toBe(actual);
 });
 
+test('map with partial path containing reserved key "constructor"', () => {
+  const from = {};
+  const actual = updateIn(from, ['constructor', 0], () => 0);
+
+  expect(from).toBe(actual);
+});
+
 test('map with reserved key "__proto__" via predicate', () => {
-  const from = { __proto__: 1 };
+  const from = {};
   const actual = updateIn(from, [(_, key) => key === '__proto__'], () => 0);
 
   expect(from).toBe(actual);
 });
 
 test('map with reserved key "constructor" via predicate', () => {
-  const from = { constructor: 1 };
+  const from = {};
   const actual = updateIn(from, [(_, key) => key === 'constructor'], () => 0);
 
   expect(from).toBe(actual);
 });
 
 test('map with reserved key "prototype" via predicate', () => {
-  const from = { prototype: 1 };
+  const from = {};
   const actual = updateIn(from, [(_, key) => key === 'prototype'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with partial path containing reserved key "constructor" via predicate', () => {
+  const from = {};
+  const actual = updateIn(from, [(_, key) => key === 'constructor', 0], () => 0);
 
   expect(from).toBe(actual);
 });
@@ -459,23 +473,37 @@ test('map with reserved key "prototype" in async', async () => {
   expect(from).toBe(actual);
 });
 
+test('map with partial path containing reserved key "constructor" in async', async () => {
+  const from = {};
+  const actual = await updateInAsync(from, ['constructor', 0], () => 0);
+
+  expect(from).toBe(actual);
+});
+
 test('map with reserved key "__proto__" via Promise predicate', async () => {
-  const from = { __proto__: 1 };
-  const actual = await updateIn(from, [(_, key) => Promise.resolve(key === '__proto__')], () => 0);
+  const from = {};
+  const actual = await updateInAsync(from, [(_, key) => Promise.resolve(key === '__proto__')], () => 0);
 
   expect(from).toBe(actual);
 });
 
 test('map with reserved key "constructor" via Promise predicate', async () => {
-  const from = { constructor: 1 };
-  const actual = await updateIn(from, [(_, key) => Promise.resolve(key === 'constructor')], () => 0);
+  const from = {};
+  const actual = await updateInAsync(from, [(_, key) => Promise.resolve(key === 'constructor')], () => 0);
 
   expect(from).toBe(actual);
 });
 
 test('map with reserved key "prototype" via Promise predicate', async () => {
-  const from = { prototype: 1 };
-  const actual = await updateIn(from, [(_, key) => Promise.resolve(key === 'prototype')], () => 0);
+  const from = {};
+  const actual = await updateInAsync(from, [(_, key) => Promise.resolve(key === 'prototype')], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with partial path containing reserved key "constructor" via Promise predicate', async () => {
+  const from = {};
+  const actual = await updateInAsync(from, [(_, key) => Promise.resolve(key === 'constructor'), Promise.resolve(true)], () => 0);
 
   expect(from).toBe(actual);
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -395,3 +395,87 @@ test('map with non-existing key followed by a Promise predicate', async () => {
   // Either way, the predicate will not able to match anything, thus, it will be no-op.
   expect(actual).toBe(from);
 });
+
+test('map with reserved key "__proto__"', () => {
+  const from = {};
+  const actual = updateIn(from, ['__proto__'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "constructor"', () => {
+  const from = {};
+  const actual = updateIn(from, ['constructor'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "prototype"', () => {
+  const from = {};
+  const actual = updateIn(from, ['prototype'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "__proto__" via predicate', () => {
+  const from = { __proto__: 1 };
+  const actual = updateIn(from, [(_, key) => key === '__proto__'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "constructor" via predicate', () => {
+  const from = { constructor: 1 };
+  const actual = updateIn(from, [(_, key) => key === 'constructor'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "prototype" via predicate', () => {
+  const from = { prototype: 1 };
+  const actual = updateIn(from, [(_, key) => key === 'prototype'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "__proto__" in async', async () => {
+  const from = {};
+  const actual = await updateInAsync(from, ['__proto__'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "constructor" in async', async () => {
+  const from = {};
+  const actual = await updateInAsync(from, ['constructor'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "prototype" in async', async () => {
+  const from = {};
+  const actual = await updateInAsync(from, ['prototype'], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "__proto__" via Promise predicate', async () => {
+  const from = { __proto__: 1 };
+  const actual = await updateIn(from, [(_, key) => Promise.resolve(key === '__proto__')], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "constructor" via Promise predicate', async () => {
+  const from = { constructor: 1 };
+  const actual = await updateIn(from, [(_, key) => Promise.resolve(key === 'constructor')], () => 0);
+
+  expect(from).toBe(actual);
+});
+
+test('map with reserved key "prototype" via Promise predicate', async () => {
+  const from = { prototype: 1 };
+  const actual = await updateIn(from, [(_, key) => Promise.resolve(key === 'prototype')], () => 0);
+
+  expect(from).toBe(actual);
+});


### PR DESCRIPTION
## Changelog

### Added

- Will not modify paths containing `__proto__`, `constructor`, and `prototype`, in PR [#19](https://github.com/compulim/simple-update-in/pull/19)