### PR TITLE
Use `Object.is` instead of `===` to check if value is updated or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    - [`rollup@^1.17.0`](https://www.npmjs.com/package/rollup)
    - [`rollup-plugin-babel@^4.3.3`](https://www.npmjs.com/package/rollup-plugin-babel)
    - [`rollup-plugin-uglify@^6.0.2`](https://www.npmjs.com/package/rollup-plugin-uglify)
+- Use `Object.is` instead of `===` to check if value is updated or not, in PR [#21](https://github.com/compulim/simple-update-in/pull/21)
+   - `Object.is` correctly compare between `0` and `-0` (different), and `NaN` and `Number.NaN` (indifferent)
 
 ### Added
 - Will skip paths containing `__proto__`, `constructor`, and `prototype`, in PR [#19](https://github.com/compulim/simple-update-in/pull/19)

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ function setValue(obj, path, target) {
         return nextObj;
       }
     } else {
-      if (nextValue === value) {
+      if (Object.is(nextValue, value)) {
         return obj;
       } else {
         nextObj = [...nextObj];
@@ -164,7 +164,7 @@ function setValue(obj, path, target) {
         return nextObj;
       }
     } else {
-      if (nextValue === value) {
+      if (Object.is(nextValue, value)) {
         return obj;
       } else {
         return {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -507,3 +507,17 @@ test('map with partial path containing reserved key "constructor" via Promise pr
 
   expect(from).toBe(actual);
 });
+
+test('update 0 with -0', () => {
+  const from = [0];
+  const actual = updateIn(from, [0], () => -0);
+
+  expect(from).not.toBe(actual);
+});
+
+test('update NaN with Number.NaN', () => {
+  const from = [NaN];
+  const actual = updateIn(from, [0], () => Number.NaN);
+
+  expect(from).toBe(actual);
+});


### PR DESCRIPTION
Fix #20.

## Changelog

### Changed

- Use `Object.is` instead of `===` to check if value is updated or not, in PR [#21](https://github.com/compulim/simple-update-in/pull/21)
   - `Object.is` correctly compare between `0` and `-0` (different), and `NaN` and `Number.NaN` (indifferent)
