### PR TITLE
Polyfill Object.is for IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fix [#24](https://github.com/compulim/simple-update-in/issues/24), polyfill `Object.is` for IE11, in PR [#XXX](https://github.com/compulim/simple-update-in/pull/XXX)
+   - Polyfill code is adopted from [`core-js`](https://npmjs.com/package/core-js) to maintain zero dependency
 
 ## [2.1.0] - 2019-07-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- Fix [#24](https://github.com/compulim/simple-update-in/issues/24), polyfill `Object.is` for IE11, in PR [#XXX](https://github.com/compulim/simple-update-in/pull/XXX)
+- Fix [#24](https://github.com/compulim/simple-update-in/issues/24), polyfill `Object.is` for IE11, in PR [#25](https://github.com/compulim/simple-update-in/pull/25)
    - Polyfill code is adopted from [`core-js`](https://npmjs.com/package/core-js) to maintain zero dependency
 
 ## [2.1.0] - 2019-07-18

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ To make `updateIn` efficient, especially, when paired with React. It will return
 
 Like other immutable framework, `updater` is expected to return a new object if there is a change. If the update do not result in a change (via [`Object.is`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is)), then, the original object is returned.
 
+> Polyfill for `Object.is` is adopted from [`core-js`](https://npmjs.com/package/core-js) to maintain zero dependency.
+
 ### Browser only
 
 You can also use in the browser via unpkg.com:

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ export default function simpleUpdateIn(obj, path, updater) {
   return obj;
 }
 
+const objectIs = Object.is || ((x, y) => x === y ? x !== 0 || 1 / x === 1 / y : x != x && y != y);
+
 async function updateInAsync(obj, path, updater) {
   validatePath(path);
 
@@ -139,7 +141,7 @@ function setValue(obj, path, target) {
         return nextObj;
       }
     } else {
-      if (Object.is(nextValue, value)) {
+      if (objectIs(nextValue, value)) {
         return obj;
       } else {
         nextObj = [...nextObj];
@@ -164,7 +166,7 @@ function setValue(obj, path, target) {
         return nextObj;
       }
     } else {
-      if (Object.is(nextValue, value)) {
+      if (objectIs(nextValue, value)) {
         return obj;
       } else {
         return {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import objectIs from './objectIs';
+
 export default function simpleUpdateIn(obj, path, updater) {
   validatePath(path);
 
@@ -13,8 +15,6 @@ export default function simpleUpdateIn(obj, path, updater) {
 
   return obj;
 }
-
-const objectIs = Object.is || ((x, y) => x === y ? x !== 0 || 1 / x === 1 / y : x != x && y != y);
 
 async function updateInAsync(obj, path, updater) {
   validatePath(path);

--- a/src/objectIs.js
+++ b/src/objectIs.js
@@ -1,0 +1,3 @@
+const objectIs = Object.is || ((x, y) => x === y ? x !== 0 || 1 / x === 1 / y : x != x && y != y);
+
+export default objectIs

--- a/src/objectIs.native.spec.js
+++ b/src/objectIs.native.spec.js
@@ -1,0 +1,5 @@
+import objectIs from './objectIs';
+
+test('Object.is should use native implementation if available', () => {
+  expect(objectIs).toBe(Object.is);
+});

--- a/src/objectIs.polyfill.spec.js
+++ b/src/objectIs.polyfill.spec.js
@@ -1,0 +1,23 @@
+describe('Object.is without native implementation', () => {
+  let objectIs;
+
+  beforeEach(() => {
+    const originalObjectIs = Object.is;
+
+    Object.is = null;
+    objectIs = require('./objectIs');
+    Object.is = originalObjectIs;
+  });
+
+  test('should return true when comparing "abc" to "abc"', () => {
+    expect(objectIs('abc', 'abc')).toBe(true);
+  });
+
+  test('should return true when comparing NaN to NaN', () => {
+    expect(objectIs(NaN, NaN)).toBe(true);
+  });
+
+  test('should return false when comparing 0 to -0', () => {
+    expect(objectIs(0, -0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

`Object.is` is not available in IE11. Thus, a polyfill is required.

We adopted the polyfill from [`core-js`](https://npmjs.com/package/core-js) to maintain zero dependency.

## Changelog

### Changed
- Fix [#24](https://github.com/compulim/simple-update-in/issues/24), polyfill `Object.is` for IE11, in PR [#25](https://github.com/compulim/simple-update-in/pull/25)
   - Polyfill code is adopted from [`core-js`](https://npmjs.com/package/core-js) to maintain zero dependency
